### PR TITLE
Inject vars to init containers

### DIFF
--- a/policies/common/Pod.yaml
+++ b/policies/common/Pod.yaml
@@ -6,7 +6,7 @@ metadata:
   name: inject-proxy-env
 spec:
   rules:
-    - name: inject-proxy-env
+    - name: inject-proxy-env-to-containers
       match:
         resources:
           kinds:
@@ -20,28 +20,53 @@ spec:
                   [[- if .Secret.Proxy.HTTP ]]
                   - name: HTTP_PROXY
                     value: [[ .Secret.Proxy.HTTP ]]
+                  - name: http_proxy
+                    value: [[ .Secret.Proxy.HTTP ]]
                   [[- end ]]
                   [[- if .Secret.Proxy.HTTPS ]]
                   - name: HTTPS_PROXY
+                    value: [[ .Secret.Proxy.HTTPS ]]
+                  - name: https_proxy
                     value: [[ .Secret.Proxy.HTTPS ]]
                   [[- end ]]
                   [[- if .Proxy.NoProxy ]]
                   - name: NO_PROXY
                     value: [[ join "," .Proxy.NoProxy ]]
+                  - name: no_proxy
+                    value: [[ join "," .Proxy.NoProxy ]]
                   [[- end ]]
+    - name: inject-proxy-env-to-init-containers
+      match:
+        resources:
+          kinds:
+            - Pod
+      preconditions:
+        any:
+        - key: "{{request.object.spec.initContainers}}"
+          operator: NotEquals
+          value: []
+      mutate:
+        patchStrategicMerge:
+          spec:
             initContainers:
               - (name): "*"
                 env:
                   [[- if .Secret.Proxy.HTTP ]]
                   - name: HTTP_PROXY
                     value: [[ .Secret.Proxy.HTTP ]]
+                  - name: http_proxy
+                    value: [[ .Secret.Proxy.HTTP ]]
                   [[- end ]]
                   [[- if .Secret.Proxy.HTTPS ]]
                   - name: HTTPS_PROXY
                     value: [[ .Secret.Proxy.HTTPS ]]
+                  - name: https_proxy
+                    value: [[ .Secret.Proxy.HTTPS ]]
                   [[- end ]]
                   [[- if .Proxy.NoProxy ]]
                   - name: NO_PROXY
+                    value: [[ join "," .Proxy.NoProxy ]]
+                  - name: no_proxy
                     value: [[ join "," .Proxy.NoProxy ]]
                   [[- end ]]
 [[- end ]]


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17254

Split policy into two rules:
* `inject-proxy-env-to-containers`
* `inject-proxy-env-to-init-containers`

The second one has a precondition so it only gets executed on init containers. There is a [bug](https://github.com/kyverno/kyverno/issues/1810) here too though and we fail with this for the pods with no init containers:
```
E0518 08:53:13.073229       1 notequal.go:37] EngineMutate "msg"="Failed to resolve variable" "error"="NotFoundVariableErr, variable request.object.spec.jobTemplate.spec.template.spec.initContainers not resolved at path " "kind"="CronJob" "name"="etcd-backup-operator-unique-scheduler" "namespace"="giantswarm" "policy"="inject-proxy-env-1" "rule"="autogen-cronjob-inject-proxy-env-to-init" "variable"=null
```

This doesn't affect the behaviour though: pods with init containers get the vars on both and pods with no init containers get it only on the normal ones (tested with `cert-operator` and `kvm-operator`). Currently running on `beaver`.