### PR TITLE
Replace cluster-operator with cluster-apps-operator

### DIFF
--- a/helm/policies-common/templates/Cluster.yaml
+++ b/helm/policies-common/templates/Cluster.yaml
@@ -26,5 +26,5 @@ spec:
           labels:
             +(cluster.x-k8s.io/watch-filter): "capi"
             cluster.x-k8s.io/watch-filter: "capi"
-            +(cluster-operator.giantswarm.io/version): "{{ `{{` }} release.spec.components | [?name == 'cluster-operator'].version | [0]{{ `}}` }}"
-            cluster-operator.giantswarm.io/version: "{{ `{{` }} release.spec.components | [?name == 'cluster-operator'].version | [0]{{ `}}` }}"
+            +(cluster-apps-operator.giantswarm.io/version): "{{ `{{` }} release.spec.components | [?name == 'cluster-apps-operator'].version | [0]{{ `}}` }}"
+            cluster-apps-operator.giantswarm.io/version: "{{ `{{` }} release.spec.components | [?name == 'cluster-apps-operator'].version | [0]{{ `}}` }}"

--- a/helm/policies-common/tests/abs/ensure.py
+++ b/helm/policies-common/tests/abs/ensure.py
@@ -12,7 +12,7 @@ import logging
 LOGGER = logging.getLogger(__name__)
 
 
-def release(kubectl, release_version, cluster_operator_version, capi_core_version):
+def release(kubectl, release_version, cluster_apps_operator_version, capi_core_version):
     r = dedent(f"""
         apiVersion: release.giantswarm.io/v1alpha1
         kind: Release
@@ -35,8 +35,8 @@ def release(kubectl, release_version, cluster_operator_version, capi_core_versio
             version: 0.0.1
           - name: cluster-api-provider-aws
             version: 0.0.1
-          - name: cluster-operator
-            version: {cluster_operator_version}
+          - name: cluster-apps-operator
+            version: {cluster_apps_operator_version}
           date: "2021-03-22T14:50:41Z"
           state: active
         status:

--- a/helm/policies-common/tests/abs/test_basic_cluster_default.py
+++ b/helm/policies-common/tests/abs/test_basic_cluster_default.py
@@ -18,12 +18,12 @@ def test_cluster_policy(kubernetes_cluster) -> None:
     cluster_name = "test-cluster"
     release_version = "20.0.0"
     capi_core_version = "capi"
-    cluster_operator_version = "2.0.0"
+    cluster_apps_operator_version = "2.0.0"
 
     obj = {}
 
     ensure.release(kubernetes_cluster.kubectl, release_version,
-                   cluster_operator_version, capi_core_version)
+                   cluster_apps_operator_version, capi_core_version)
     ensure.cluster(kubernetes_cluster.kubectl,
                    cluster_name, release_version)
 
@@ -32,7 +32,7 @@ def test_cluster_policy(kubernetes_cluster) -> None:
 
     cluster = yaml.safe_load(raw)
 
-    assert cluster['metadata']['labels']['cluster-operator.giantswarm.io/version'] == cluster_operator_version
+    assert cluster['metadata']['labels']['cluster-apps-operator.giantswarm.io/version'] == cluster_apps_operator_version
     assert cluster['metadata']['labels']['cluster.x-k8s.io/watch-filter'] == capi_core_version
 
 
@@ -42,12 +42,12 @@ def test_machine_deployment_policy(kubernetes_cluster) -> None:
     cluster_name = "test-cluster-md"
     release_version = "20.0.0"
     capi_core_version = "capi"
-    cluster_operator_version = "2.0.0"
+    cluster_apps_operator_version = "2.0.0"
 
     obj = {}
 
     ensure.release(kubernetes_cluster.kubectl, release_version,
-                   cluster_operator_version, capi_core_version)
+                   cluster_apps_operator_version, capi_core_version)
     ensure.cluster(kubernetes_cluster.kubectl,
                    cluster_name, release_version)
     ensure.machine_deployment(kubernetes_cluster.kubectl, cluster_name,

--- a/policies/common/Cluster.yaml
+++ b/policies/common/Cluster.yaml
@@ -26,5 +26,5 @@ spec:
           labels:
             +(cluster.x-k8s.io/watch-filter): "capi"
             cluster.x-k8s.io/watch-filter: "capi"
-            +(cluster-operator.giantswarm.io/version): "{{ release.spec.components | [?name == 'cluster-operator'].version | [0]}}"
-            cluster-operator.giantswarm.io/version: "{{ release.spec.components | [?name == 'cluster-operator'].version | [0]}}"
+            +(cluster-apps-operator.giantswarm.io/version): "{{ release.spec.components | [?name == 'cluster-apps-operator'].version | [0]}}"
+            cluster-apps-operator.giantswarm.io/version: "{{ release.spec.components | [?name == 'cluster-apps-operator'].version | [0]}}"


### PR DESCRIPTION
Towards giantswarm/roadmap#320

First 0.1.0 release is out so I'd like to switch to the new operator.

I have a doubt about the version label. Do we want it to have the static `capi` value? I did try that but its blocked by the validation on release CRs.

If that is needed I'd like to do it as a follow up step.

