### PR TITLE
aws-default-cp-instance-type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add default for aws control plane instance type.
+
 ## [0.0.2] - 2021-07-12
 
 ### Added

--- a/helm/policies-aws/templates/AWSCAPI.yaml
+++ b/helm/policies-aws/templates/AWSCAPI.yaml
@@ -113,3 +113,20 @@ spec:
               {{ `{{` }} regex_replace_all('^$', '{{ `{{` }}@{{ `}}` }}', '{{ .Values.awsClusterRoleIdentity.sourceIdentityRef.name}}') {{ `}}` }}
             kind: |-
               {{ `{{` }} regex_replace_all('^$', '{{ `{{` }}@{{ `}}` }}', '{{ .Values.awsClusterRoleIdentity.sourceIdentityRef.kind }}') {{ `}}` }}
+  # awsmachinetemplate-default-empty-string adds default values to fields in a AWSMachineTemplate CR if it has the watch-filter label and the values are empty strings.
+  # its used to default instanceType for a control plane machine in case its empty
+  - name: awsmachinetemplate-default-empty-string
+    match:
+      resources:
+        kinds:
+        - infrastructure.cluster.x-k8s.io/v1alpha3/AWSMachineTemplate
+        selector:
+          matchLabels:
+            cluster.x-k8s.io/watch-filter: capi
+    mutate:
+      patchStrategicMerge:
+        spec:
+          template:
+            spec:
+              instanceType: |-
+                {{ `{{` }} regex_replace_all('^$', '{{ `{{` }}@{{ `}}` }}', '{{ .Values.awsControlPlane.instanceType }}') {{ `}}` }}

--- a/helm/policies-aws/templates/AWSCAPI.yaml
+++ b/helm/policies-aws/templates/AWSCAPI.yaml
@@ -113,6 +113,21 @@ spec:
               {{ `{{` }} regex_replace_all('^$', '{{ `{{` }}@{{ `}}` }}', '{{ .Values.awsClusterRoleIdentity.sourceIdentityRef.name}}') {{ `}}` }}
             kind: |-
               {{ `{{` }} regex_replace_all('^$', '{{ `{{` }}@{{ `}}` }}', '{{ .Values.awsClusterRoleIdentity.sourceIdentityRef.kind }}') {{ `}}` }}
+  # awsmachinetemplate-default adds default values to fields in a AWSMachineTemplate CR if it has the watch-filter label and the values are completely missing.
+  - name: awsmachinetemplate-default
+    match:
+      resources:
+        kinds:
+        - infrastructure.cluster.x-k8s.io/v1alpha3/AWSMachineTemplate
+        selector:
+          matchLabels:
+            cluster.x-k8s.io/watch-filter: capi
+    mutate:
+      patchesJson6902: |-
+        - op: add
+          path: "/spec/template/spec/instanceType"
+          value: {{ .Values.awsControlPlane.instanceType }}
+
   # awsmachinetemplate-default-empty-string adds default values to fields in a AWSMachineTemplate CR if it has the watch-filter label and the values are empty strings.
   # its used to default instanceType for a control plane machine in case its empty
   - name: awsmachinetemplate-default-empty-string

--- a/helm/policies-aws/values.yaml
+++ b/helm/policies-aws/values.yaml
@@ -5,3 +5,6 @@ awsClusterRoleIdentity:
   sourceIdentityRef:
     name: default
     kind: AWSClusterControllerIdentity
+
+awsControlPlane:
+  instanceType: t3.large

--- a/policies/aws/AWSCAPI.yaml
+++ b/policies/aws/AWSCAPI.yaml
@@ -112,3 +112,20 @@ spec:
               {{ regex_replace_all('^$', '{{@}}', '[[ .Values.awsClusterRoleIdentity.sourceIdentityRef.name]]') }}
             kind: |-
               {{ regex_replace_all('^$', '{{@}}', '[[ .Values.awsClusterRoleIdentity.sourceIdentityRef.kind ]]') }}
+  # awsmachinetemplate-default-empty-string adds default values to fields in a AWSMachineTemplate CR if it has the watch-filter label and the values are empty strings.
+  # its used to default instanceType for a control plane machine in case its empty
+  - name: awsmachinetemplate-default-empty-string
+    match:
+      resources:
+        kinds:
+        - infrastructure.cluster.x-k8s.io/v1alpha3/AWSMachineTemplate
+        selector:
+          matchLabels:
+            cluster.x-k8s.io/watch-filter: capi
+    mutate:
+      patchStrategicMerge:
+        spec:
+          template:
+            spec:
+              instanceType: |-
+                {{ regex_replace_all('^$', '{{@}}', '[[ .Values.awsControlPlane.instanceType ]]') }}

--- a/policies/aws/AWSCAPI.yaml
+++ b/policies/aws/AWSCAPI.yaml
@@ -112,6 +112,21 @@ spec:
               {{ regex_replace_all('^$', '{{@}}', '[[ .Values.awsClusterRoleIdentity.sourceIdentityRef.name]]') }}
             kind: |-
               {{ regex_replace_all('^$', '{{@}}', '[[ .Values.awsClusterRoleIdentity.sourceIdentityRef.kind ]]') }}
+  # awsmachinetemplate-default adds default values to fields in a AWSMachineTemplate CR if it has the watch-filter label and the values are completely missing.
+  - name: awsmachinetemplate-default
+    match:
+      resources:
+        kinds:
+        - infrastructure.cluster.x-k8s.io/v1alpha3/AWSMachineTemplate
+        selector:
+          matchLabels:
+            cluster.x-k8s.io/watch-filter: capi
+    mutate:
+      patchesJson6902: |-
+        - op: add
+          path: "/spec/template/spec/instanceType"
+          value: [[ .Values.awsControlPlane.instanceType ]]
+
   # awsmachinetemplate-default-empty-string adds default values to fields in a AWSMachineTemplate CR if it has the watch-filter label and the values are empty strings.
   # its used to default instanceType for a control plane machine in case its empty
   - name: awsmachinetemplate-default-empty-string


### PR DESCRIPTION
add defaulting for instanceType used for control plane machine
(it was empty before and cluster creation failed)