### PR TITLE
add command to add default label to worker nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add default command to label workers nodes properly.
+
 ## [0.0.4] - 2021-07-14
 
 ## [0.0.3] - 2021-07-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add default command to label workers nodes properly.
+- Add defaulting to set custom labels on master and worker nodes.
 
 ## [0.0.4] - 2021-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add defaulting to set custom labels on master and worker nodes.
+- Add defaulting to set custom labels on worker nodes.
 
 ## [0.0.4] - 2021-07-14
 

--- a/helm/policies-common/templates/CoreCAPI.yaml
+++ b/helm/policies-common/templates/CoreCAPI.yaml
@@ -81,9 +81,9 @@ spec:
                 nodeRegistration:
                   kubeletExtraArgs:
                     healthz-bind-address: 0.0.0.0
-              postKubeadmCommands:
-                - 'kubectl --kubeconfig=/etc/kubernetes/admin.conf label node {{ `{{` }} ds.meta_data.local_hostname {{ `}}` }} node-role.kubernetes.io/worker=""'
-  - name: kubeadmconfig
+                    node-labels: role=worker
+
+  - name: kubeadmconfig-defaults
     match:
       resources:
         kinds:
@@ -100,8 +100,7 @@ spec:
                 nodeRegistration:
                   kubeletExtraArgs:
                     healthz-bind-address: 0.0.0.0
-              postKubeadmCommands:
-                - 'kubectl --kubeconfig=/etc/kubernetes/admin.conf label node {{ `{{` }} ds.meta_data.local_hostname {{ `}}` }} node-role.kubernetes.io/worker=""'
+                    node-labels: role=worker
 
   - name: kubeadmcontrolplane-defaults
     match:
@@ -126,3 +125,4 @@ spec:
               nodeRegistration:
                 kubeletExtraArgs:
                   healthz-bind-address: 0.0.0.0
+                  node-labels: role=master

--- a/helm/policies-common/templates/CoreCAPI.yaml
+++ b/helm/policies-common/templates/CoreCAPI.yaml
@@ -125,4 +125,3 @@ spec:
               nodeRegistration:
                 kubeletExtraArgs:
                   healthz-bind-address: 0.0.0.0
-                  node-labels: role=master

--- a/helm/policies-common/templates/CoreCAPI.yaml
+++ b/helm/policies-common/templates/CoreCAPI.yaml
@@ -81,6 +81,27 @@ spec:
                 nodeRegistration:
                   kubeletExtraArgs:
                     healthz-bind-address: 0.0.0.0
+              postKubeadmCommands:
+                - 'kubectl --kubeconfig=/etc/kubernetes/admin.conf label node {{ `{{` }} ds.meta_data.local_hostname {{ `}}` }} node-role.kubernetes.io/worker=""'
+  - name: kubeadmconfig
+    match:
+      resources:
+        kinds:
+        - bootstrap.cluster.x-k8s.io/v1alpha3/KubeadmConfig
+        selector:
+          matchLabels:
+            cluster.x-k8s.io/watch-filter: capi
+    mutate:
+      patchStrategicMerge:
+        spec:
+          template:
+            spec:
+              joinConfiguration:
+                nodeRegistration:
+                  kubeletExtraArgs:
+                    healthz-bind-address: 0.0.0.0
+              postKubeadmCommands:
+                - 'kubectl --kubeconfig=/etc/kubernetes/admin.conf label node {{ `{{` }} ds.meta_data.local_hostname {{ `}}` }} node-role.kubernetes.io/worker=""'
 
   - name: kubeadmcontrolplane-defaults
     match:

--- a/policies/common/CoreCAPI.yaml
+++ b/policies/common/CoreCAPI.yaml
@@ -124,4 +124,3 @@ spec:
               nodeRegistration:
                 kubeletExtraArgs:
                   healthz-bind-address: 0.0.0.0
-                  node-labels: role=master

--- a/policies/common/CoreCAPI.yaml
+++ b/policies/common/CoreCAPI.yaml
@@ -81,7 +81,8 @@ spec:
                   kubeletExtraArgs:
                     healthz-bind-address: 0.0.0.0
                     node-labels: role=worker
-  - name: kubeadmconfig
+
+  - name: kubeadmconfig-defaults
     match:
       resources:
         kinds:

--- a/policies/common/CoreCAPI.yaml
+++ b/policies/common/CoreCAPI.yaml
@@ -80,8 +80,7 @@ spec:
                 nodeRegistration:
                   kubeletExtraArgs:
                     healthz-bind-address: 0.0.0.0
-              postKubeadmCommands:
-                - 'kubectl --kubeconfig=/etc/kubernetes/admin.conf label node {{ ds.meta_data.local_hostname }} node-role.kubernetes.io/worker=""'
+                    node-labels: role=worker
   - name: kubeadmconfig
     match:
       resources:
@@ -99,8 +98,7 @@ spec:
                 nodeRegistration:
                   kubeletExtraArgs:
                     healthz-bind-address: 0.0.0.0
-              postKubeadmCommands:
-                - 'kubectl --kubeconfig=/etc/kubernetes/admin.conf label node {{ ds.meta_data.local_hostname }} node-role.kubernetes.io/worker=""'
+                    node-labels: role=worker
 
   - name: kubeadmcontrolplane-defaults
     match:
@@ -125,3 +123,4 @@ spec:
               nodeRegistration:
                 kubeletExtraArgs:
                   healthz-bind-address: 0.0.0.0
+                  node-labels: role=master

--- a/policies/common/CoreCAPI.yaml
+++ b/policies/common/CoreCAPI.yaml
@@ -80,6 +80,27 @@ spec:
                 nodeRegistration:
                   kubeletExtraArgs:
                     healthz-bind-address: 0.0.0.0
+              postKubeadmCommands:
+                - 'kubectl --kubeconfig=/etc/kubernetes/admin.conf label node {{ ds.meta_data.local_hostname }} node-role.kubernetes.io/worker=""'
+  - name: kubeadmconfig
+    match:
+      resources:
+        kinds:
+        - bootstrap.cluster.x-k8s.io/v1alpha3/KubeadmConfig
+        selector:
+          matchLabels:
+            cluster.x-k8s.io/watch-filter: capi
+    mutate:
+      patchStrategicMerge:
+        spec:
+          template:
+            spec:
+              joinConfiguration:
+                nodeRegistration:
+                  kubeletExtraArgs:
+                    healthz-bind-address: 0.0.0.0
+              postKubeadmCommands:
+                - 'kubectl --kubeconfig=/etc/kubernetes/admin.conf label node {{ ds.meta_data.local_hostname }} node-role.kubernetes.io/worker=""'
 
   - name: kubeadmcontrolplane-defaults
     match:


### PR DESCRIPTION
ATM we have a problem that there is no usable label on worker nodes for capa that would help us schedule apps like `kiam-agent` which need to run only on workers

I tried lots of stuff, unfortunately, there is no easy way how to add restricted labels like `node-role.kubrnetes.io/worker` or `kubernetes.io/role=worker` on the each worker automatically

`kubeadm` cannot do it on boot phase (https://cluster-api.sigs.k8s.io/user/troubleshooting.html?highlight=kubelet#labeling-nodes-with-reserved-labels-such-as-node-rolekubernetesio-fails-with-kubeadm-error-during-bootstrap )  and I even tried to run `kubectl label node` as post-kubeadm command but kubeconfig on the worker does not have enough RBAC permission to apply restricted labels.

So for now adding this simple `role=worker` label and use this branch of `kiam-app` https://github.com/giantswarm/kiam-app/pull/84  which will be part of 20.0.0 release.

I want to move on and have a GS-like cluster spawned with CAPA asap, we could revisit this later, for now it's not hurting anything.

slack thread https://gigantic.slack.com/archives/CQZA6GGAY/p1626332796008500

master nodes have a proper label set automatically so we we can use that.