### PR TITLE
Fix circle ci config to act on tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,7 @@ workflows:
           on_tag: false
           requires:
             - test-policies
+
       # Shared
       - architect/push-to-app-catalog:
           name: push-policies-shared-to-catalog
@@ -122,7 +123,6 @@ workflows:
           chart: policies-shared
           context: "architect"
           explicit_allow_chart_name_mismatch: true
-          on_tag: false
           requires:
             - test-policies
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,6 @@ workflows:
           chart: policies-common
           context: "architect"
           explicit_allow_chart_name_mismatch: true
-          on_tag: false
           requires:
             - test-policies
       # AWS
@@ -98,7 +97,6 @@ workflows:
           chart: policies-aws
           context: "architect"
           explicit_allow_chart_name_mismatch: true
-          on_tag: false
           requires:
             - test-policies
       # Azure
@@ -110,7 +108,6 @@ workflows:
           chart: policies-azure
           context: "architect"
           explicit_allow_chart_name_mismatch: true
-          on_tag: false
           requires:
             - test-policies
 


### PR DESCRIPTION
Removing the on_tag = false otherwise the shared policy will not be added to collections :)