### PR TITLE
Default `spec.location` field for CAPZ `AzureCluster` CRs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Default `spec.location` field for CAPZ `AzureCluster` CRs.
+
 ## [0.2.0] - 2021-08-31
 
 ### Changed

--- a/helm/policies-azure/templates/AzureCAPI.yaml
+++ b/helm/policies-azure/templates/AzureCAPI.yaml
@@ -52,3 +52,15 @@ spec:
               controllerManager:
                 extraArgs:
                   allocate-node-cidrs: "true"
+  - name: azurecluster-ensure-location-and-subscription-id
+    match:
+      resources:
+        kinds:
+          - infrastructure.cluster.x-k8s.io/v1alpha4/AzureCluster
+        selector:
+          matchLabels:
+            cluster.x-k8s.io/watch-filter: capi
+    mutate:
+      patchStrategicMerge:
+        spec:
+          location: {{ .Values.location }}

--- a/helm/policies-azure/tests/abs/test_azure_default.py
+++ b/helm/policies-azure/tests/abs/test_azure_default.py
@@ -30,6 +30,7 @@ def test_azure_cluster_policy(release, cluster_v1alpha4, azurecluster) -> None:
     :param azurecluster: AzureCluster CR with empty strings which matches the Cluster CR.
     """
     assert azurecluster['metadata']['labels']['cluster.x-k8s.io/watch-filter'] == ensure.watch_label
+    assert azurecluster['spec']['location'] == "westeurope"
 
 @pytest.mark.smoke
 def test_kcp_allocate_node_cidrs(kubeadm_control_plane) -> None:

--- a/helm/policies-azure/values.yaml
+++ b/helm/policies-azure/values.yaml
@@ -1,0 +1,1 @@
+location: "westeurope"

--- a/helm/tests/ensure.py
+++ b/helm/tests/ensure.py
@@ -402,6 +402,8 @@ def azurecluster(kubernetes_cluster):
           labels:
             giantswarm.io/cluster: {cluster_name}
             cluster.x-k8s.io/cluster-name: {cluster_name}
+        spec:
+          location: ""
     """)
 
     kubernetes_cluster.kubectl("apply", input=c, output=None)

--- a/policies/azure/AzureCAPI.yaml
+++ b/policies/azure/AzureCAPI.yaml
@@ -51,3 +51,15 @@ spec:
               controllerManager:
                 extraArgs:
                   allocate-node-cidrs: "true"
+  - name: azurecluster-ensure-location-and-subscription-id
+    match:
+      resources:
+        kinds:
+          - infrastructure.cluster.x-k8s.io/v1alpha4/AzureCluster
+        selector:
+          matchLabels:
+            cluster.x-k8s.io/watch-filter: capi
+    mutate:
+      patchStrategicMerge:
+        spec:
+          location: [[ .Values.location ]]


### PR DESCRIPTION
This PR adds defaulting of the `location` (read: region) field for `AzureCluster` CR.
This is needed because kubectl-gs does not have this information when generating the cluster templates and thus leaves it blank.

### Checklist

- [x] Update changelog in CHANGELOG.md.
