### PR TITLE
Default `spec.location` field for CAPZ `AzureMachinePool` CRs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Default `spec.location` field for CAPZ `AzureMachinePool` CRs.
+
 ## [0.3.0] - 2021-09-02
 
 ### Added

--- a/hack/setup-local.sh
+++ b/hack/setup-local.sh
@@ -15,6 +15,7 @@ kubectl create --context kind-kyverno-cluster -f https://raw.githubusercontent.c
 kubectl create --context kind-kyverno-cluster -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-aws/main/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinetemplates.yaml
 kubectl create --context kind-kyverno-cluster -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-aws/main/config/crd/bases/infrastructure.cluster.x-k8s.io_awsclusterroleidentities.yaml
 # CAPZ CRDs
-kubectl create --context kind-kyverno-cluster -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/master/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+kubectl create --context kind-kyverno-cluster -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+kubectl create --context kind-kyverno-cluster -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
 # Kyverno
 kubectl create --context kind-kyverno-cluster -f https://raw.githubusercontent.com/kyverno/kyverno/v1.4.1/definitions/release/install.yaml

--- a/helm/policies-azure/templates/AzureCAPI.yaml
+++ b/helm/policies-azure/templates/AzureCAPI.yaml
@@ -52,11 +52,12 @@ spec:
               controllerManager:
                 extraArgs:
                   allocate-node-cidrs: "true"
-  - name: azurecluster-ensure-location-and-subscription-id
+  - name: ensure-location
     match:
       resources:
         kinds:
           - infrastructure.cluster.x-k8s.io/v1alpha4/AzureCluster
+          - infrastructure.cluster.x-k8s.io/v1alpha4/AzureMachinePool
         selector:
           matchLabels:
             cluster.x-k8s.io/watch-filter: capi

--- a/helm/policies-azure/tests/abs/test_azure_default.py
+++ b/helm/policies-azure/tests/abs/test_azure_default.py
@@ -13,6 +13,7 @@ from ensure import release
 from ensure import cluster_v1alpha4
 from ensure import azurecluster
 from ensure import kubeadm_control_plane
+from ensure import azuremachinepool
 
 import pytest
 from pytest_kube import forward_requests, wait_for_rollout, app_template
@@ -26,7 +27,7 @@ def test_azure_cluster_policy(release, cluster_v1alpha4, azurecluster) -> None:
     test_azure_cluster_policy tests defaulting of an AzureCluster where all required values are empty strings.
 
     :param release: Release CR which is used by the Cluster.
-    :param cluster: Cluster CR which uses the release and matches the AzureCluster.
+    :param cluster_v1alpha4: Cluster CR which uses the release and matches the AzureCluster.
     :param azurecluster: AzureCluster CR with empty strings which matches the Cluster CR.
     """
     assert azurecluster['metadata']['labels']['cluster.x-k8s.io/watch-filter'] == ensure.watch_label
@@ -40,3 +41,15 @@ def test_kcp_allocate_node_cidrs(kubeadm_control_plane) -> None:
     :param kubeadm_control_plane: KubeadmControlPlane CR created from an empty spec.
     """
     assert kubeadm_control_plane['spec']['kubeadmConfigSpec']['clusterConfiguration']['controllerManager']['extraArgs']['allocate-node-cidrs'] == "true"
+
+@pytest.mark.smoke
+def test_azure_machine_pool_default(release, cluster_v1alpha4, azuremachinepool) -> None:
+    """
+    test_azure_machine_pool_default tests defaulting of an AzureMachinePool where all required values are empty strings.
+
+    :param release: Release CR which is used by the Cluster.
+    :param cluster_v1alpha4: Cluster CR which uses the release and matches the AzureCluster.
+    :param azuremachinepool: AzureMachinePool CR with empty strings which matches the Cluster CR.
+    """
+    assert azuremachinepool['metadata']['labels']['cluster.x-k8s.io/watch-filter'] == ensure.watch_label
+    assert azuremachinepool['spec']['location'] == "westeurope"

--- a/policies/azure/AzureCAPI.yaml
+++ b/policies/azure/AzureCAPI.yaml
@@ -51,11 +51,12 @@ spec:
               controllerManager:
                 extraArgs:
                   allocate-node-cidrs: "true"
-  - name: azurecluster-ensure-location-and-subscription-id
+  - name: ensure-location
     match:
       resources:
         kinds:
           - infrastructure.cluster.x-k8s.io/v1alpha4/AzureCluster
+          - infrastructure.cluster.x-k8s.io/v1alpha4/AzureMachinePool
         selector:
           matchLabels:
             cluster.x-k8s.io/watch-filter: capi


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/18620

This PR defaults the location (region) field for azure machine pool CRs.

### Checklist

- [x] Update changelog in CHANGELOG.md.
