### PR TITLE
Add a feature gate so that tests can run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add CRDs related to kubeadm controlplane to CI.
+- Add RemoveSelfLink feature gate to kind cluster.
 
 ## [0.5.0] - 2021-09-13
 

--- a/hack/cluster-conf.yaml
+++ b/hack/cluster-conf.yaml
@@ -1,0 +1,4 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  "RemoveSelfLink": false

--- a/hack/setup-local.sh
+++ b/hack/setup-local.sh
@@ -1,4 +1,4 @@
-kind create cluster --image quay.io/giantswarm/kind-node:$1 --name kyverno-cluster
+kind create cluster --config $(pwd)/hack/cluster-conf.yaml --image quay.io/giantswarm/kind-node:$1 --name kyverno-cluster
 kubectl wait nodes/kyverno-cluster-control-plane --for=condition=ready --timeout=5m > /dev/null
 kind get kubeconfig --name kyverno-cluster > $(pwd)/kube.config
 # Giant Swarm CRDs


### PR DESCRIPTION
Currently tests are failing because app-operator breaks with:
```
{"caller":"github.com/giantswarm/operatorkit/v4/pkg/controller/controller.go:316","controller":"app-operator-app","event":"update","level":"error","loop":"69","message":"failed to reconcile","object":"","
stack":{"annotation":"forbidden: User \"system:serviceaccount:giantswarm:app-operator-unique\" cannot patch path \"/\"","kind":"unknown","stack":[{"file":"/go/pkg/mod/github.com/giantswarm/operatorkit/v4@
v4.2.0/pkg/controller/finalizer.go","line":70},{"file":"/go/pkg/mod/github.com/giantswarm/backoff@v0.2.0/retry.go","line":13},{"file":"/go/pkg/mod/github.com/giantswarm/operatorkit/v4@v4.2.0/pkg/controlle
r/finalizer.go","line":80},{"file":"/go/pkg/mod/github.com/giantswarm/operatorkit/v4@v4.2.0/pkg/controller/controller.go","line":528},{"file":"/go/pkg/mod/github.com/giantswarm/operatorkit/v4@v4.2.0/pkg/c
ontroller/controller.go","line":514}]},"time":"2021-09-15T08:24:02.66532+00:00","version":"1229"}
```

More context here: https://gigantic.slack.com/archives/CRZN9GLJW/p1617721636186300
### Checklist

- [x] Update changelog in CHANGELOG.md.
