### PR TITLE
Added kubelet and api server args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- kubelet and api server flags for CAPI clusters.
+
 ## [0.7.1] - 2021-10-12
 
 ### Fixed
@@ -17,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Default SubscriptionID field for `AzureCluster` CRs. 
+- Default SubscriptionID field for `AzureCluster` CRs.
 
 ### Changed
 

--- a/helm/policies-common/templates/CoreCAPI.yaml
+++ b/helm/policies-common/templates/CoreCAPI.yaml
@@ -218,6 +218,8 @@ spec:
             nodeRegistration:
               kubeletExtraArgs:
                 +(node-labels): role=worker
+                +(v): "2"
+                +(image-pull-progress-deadline): "{{ .Values.Installation.V1.Guest.Kubernetes.Kubelet.ImagePullProgressDeadline }}"
 
   - name: kubeadmcontrolplane-defaults
     match:
@@ -244,8 +246,104 @@ spec:
               scheduler:
                 extraArgs:
                   bind-address: 0.0.0.0
+              apiServer:
+                extraArgs:
+                  audit-log-maxage: "30"
+                  audit-log-maxbackup: "30"
+                  audit-log-maxsize: "100"
+                  audit-log-path: "/var/log/apiserver/audit.log"
+                  audit-policy-file: "/etc/kubernetes/policies/audit-policy.yaml"
+                  encryption-provider-config: "/etc/kubernetes/encryption/k8s-encryption-config.yaml"
+                  service-account-lookup: "true"
+                  enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,PodSecurityPolicy,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook"
+                  kubelet-preferred-address-types: "InternalIP"
+                  +(profiling): "false"
+                  +(tls-cipher-suites): "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
             initConfiguration:
               nodeRegistration:
                 kubeletExtraArgs:
                   healthz-bind-address: 0.0.0.0
                   node-ip: "{{ `{{` }} dictionary.data.nodeip {{ `}}` }}"
+                  +(v): "2"
+                  +(image-pull-progress-deadline): "{{ .Values.Installation.V1.Guest.Kubernetes.Kubelet.ImagePullProgressDeadline }}"
+
+# NOTE: It's currently not possible to check for a key either being missing or checking its value.
+# This should be fixed in Kyverno 1.4.2 where missing keys are replaced with "" but there is
+# currently a regression bug which prevents us from being able to upgrade.
+# Once this is resolved the following two policies should be enabled and the `kubeadmcontrolplane-apiserverargs`
+# policy can be removed.
+
+  # - name: kubeadmcontrolplane-merge-runtimeconfig-flags
+  #   match:
+  #     resources:
+  #       kinds:
+  #       - controlplane.cluster.x-k8s.io/v1alpha3/KubeadmControlPlane
+  #       - controlplane.cluster.x-k8s.io/v1alpha4/KubeadmControlPlane
+  #       selector:
+  #         matchLabels:
+  #           cluster.x-k8s.io/watch-filter: capi
+  #   preconditions:
+  #     any:
+  #     - key: "{{ `{{` }}request.object.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.\"runtime-config\"{{ `}}` }}"
+  #       operator: Equals
+  #       value: ""
+  #     - key: "{{ `{{` }}request.object.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.\"runtime-config\"{{ `}}` }}"
+  #       operator: NotEquals
+  #       value: "*api/all=*"
+  #     - key: "{{ `{{` }}request.object.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.\"runtime-config\"{{ `}}` }}"
+  #       operator: NotEquals
+  #       value: "*scheduling.k8s.io/v1alpha1=*"
+  #   mutate:
+  #     patchStrategicMerge:
+  #       spec:
+  #         kubeadmConfigSpec:
+  #           clusterConfiguration:
+  #             apiServer:
+  #               extraArgs:
+  #                 runtime-config: "{{ `{{` }} join(',', ['api/all=true', 'scheduling.k8s.io/v1alpha1=true', request.object.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.\"runtime-config\"]) {{ `}}` }}"
+
+
+  # - name: kubeadmcontrolplane-merge-featuregates-flags
+  #   match:
+  #     resources:
+  #       kinds:
+  #       - controlplane.cluster.x-k8s.io/v1alpha3/KubeadmControlPlane
+  #       - controlplane.cluster.x-k8s.io/v1alpha4/KubeadmControlPlane
+  #       selector:
+  #         matchLabels:
+  #           cluster.x-k8s.io/watch-filter: capi
+  #   preconditions:
+  #     any:
+  #     - key: "{{ `{{` }}request.object.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.\"feature-gates\"{{ `}}` }}"
+  #       operator: Equals
+  #       value: ""
+  #     - key: "{{ `{{` }}request.object.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.\"feature-gates\"{{ `}}` }}"
+  #       operator: NotEquals
+  #       value: "*TTLAfterFinished=*"
+  #   mutate:
+  #     patchStrategicMerge:
+  #       spec:
+  #         kubeadmConfigSpec:
+  #           clusterConfiguration:
+  #             apiServer:
+  #               extraArgs:
+  #                 feature-gates: "{{ `{{` }} join(',', ['TTLAfterFinished=true', request.object.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.\"feature-gates\"]) {{ `}}` }}"
+
+  - name: kubeadmcontrolplane-apiserverargs
+    match:
+      resources:
+        kinds:
+        - controlplane.cluster.x-k8s.io/v1alpha3/KubeadmControlPlane
+        - controlplane.cluster.x-k8s.io/v1alpha4/KubeadmControlPlane
+        selector:
+          matchLabels:
+            cluster.x-k8s.io/watch-filter: capi
+    mutate:
+      patchStrategicMerge:
+        spec:
+          kubeadmConfigSpec:
+            clusterConfiguration:
+              apiServer:
+                extraArgs:
+                  +(feature-gates): "TTLAfterFinished=true"
+                  +(runtime-config): "api/all=true,scheduling.k8s.io/v1alpha1=true"

--- a/helm/policies-common/values.yaml
+++ b/helm/policies-common/values.yaml
@@ -2,5 +2,9 @@ Installation:
   V1:
     Proxy:
       Enabled: false
+    Guest:
+      Kubernetes:
+        Kubelet:
+          ImagePullProgressDeadline: 10m
 
 clusterDescription: "Unnamed Cluster"

--- a/helm/tests/ensure.py
+++ b/helm/tests/ensure.py
@@ -282,6 +282,38 @@ def kubeadmconfig_with_role_labels(kubernetes_cluster):
     kubernetes_cluster.kubectl(f"delete kubeadmconfig {cluster_name}", output=None)
     LOGGER.info(f"KubeadmConfig {cluster_name} deleted")
 
+@pytest.fixture
+def kubeadmconfig_with_kubelet_args(kubernetes_cluster):
+    md = dedent(f"""
+        apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+        kind: KubeadmConfig
+        metadata:
+          name: {cluster_name}
+          labels:
+            giantswarm.io/cluster: {cluster_name}
+            cluster.x-k8s.io/cluster-name: {cluster_name}
+            cluster.x-k8s.io/watch-filter: {watch_label}
+        spec:
+          joinConfiguration:
+            nodeRegistration:
+              kubeletExtraArgs:
+                v: "1"
+                image-pull-progress-deadline: 1m
+    """)
+
+    kubernetes_cluster.kubectl("apply", input=md, output=None)
+    LOGGER.info(f"KubeadmConfig {cluster_name} applied")
+
+    raw = kubernetes_cluster.kubectl(
+        f"get kubeadmconfig {cluster_name}", output="yaml")
+
+    kubeadmconfig = yaml.safe_load(raw)
+
+    yield kubeadmconfig
+
+    kubernetes_cluster.kubectl(f"delete kubeadmconfig {cluster_name}", output=None)
+    LOGGER.info(f"KubeadmConfig {cluster_name} deleted")
+
 
 @pytest.fixture
 def kubeadmconfig_controlplane(kubernetes_cluster):

--- a/policies/common/CoreCAPI.yaml
+++ b/policies/common/CoreCAPI.yaml
@@ -217,6 +217,8 @@ spec:
             nodeRegistration:
               kubeletExtraArgs:
                 +(node-labels): role=worker
+                +(v): "2"
+                +(image-pull-progress-deadline): "[[ .Values.Installation.V1.Guest.Kubernetes.Kubelet.ImagePullProgressDeadline ]]"
 
   - name: kubeadmcontrolplane-defaults
     match:
@@ -243,8 +245,104 @@ spec:
               scheduler:
                 extraArgs:
                   bind-address: 0.0.0.0
+              apiServer:
+                extraArgs:
+                  audit-log-maxage: "30"
+                  audit-log-maxbackup: "30"
+                  audit-log-maxsize: "100"
+                  audit-log-path: "/var/log/apiserver/audit.log"
+                  audit-policy-file: "/etc/kubernetes/policies/audit-policy.yaml"
+                  encryption-provider-config: "/etc/kubernetes/encryption/k8s-encryption-config.yaml"
+                  service-account-lookup: "true"
+                  enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,PodSecurityPolicy,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook"
+                  kubelet-preferred-address-types: "InternalIP"
+                  +(profiling): "false"
+                  +(tls-cipher-suites): "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
             initConfiguration:
               nodeRegistration:
                 kubeletExtraArgs:
                   healthz-bind-address: 0.0.0.0
                   node-ip: "{{ dictionary.data.nodeip }}"
+                  +(v): "2"
+                  +(image-pull-progress-deadline): "[[ .Values.Installation.V1.Guest.Kubernetes.Kubelet.ImagePullProgressDeadline ]]"
+
+# NOTE: It's currently not possible to check for a key either being missing or checking its value.
+# This should be fixed in Kyverno 1.4.2 where missing keys are replaced with "" but there is
+# currently a regression bug which prevents us from being able to upgrade.
+# Once this is resolved the following two policies should be enabled and the `kubeadmcontrolplane-apiserverargs`
+# policy can be removed.
+
+  # - name: kubeadmcontrolplane-merge-runtimeconfig-flags
+  #   match:
+  #     resources:
+  #       kinds:
+  #       - controlplane.cluster.x-k8s.io/v1alpha3/KubeadmControlPlane
+  #       - controlplane.cluster.x-k8s.io/v1alpha4/KubeadmControlPlane
+  #       selector:
+  #         matchLabels:
+  #           cluster.x-k8s.io/watch-filter: capi
+  #   preconditions:
+  #     any:
+  #     - key: "{{request.object.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.\"runtime-config\"}}"
+  #       operator: Equals
+  #       value: ""
+  #     - key: "{{request.object.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.\"runtime-config\"}}"
+  #       operator: NotEquals
+  #       value: "*api/all=*"
+  #     - key: "{{request.object.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.\"runtime-config\"}}"
+  #       operator: NotEquals
+  #       value: "*scheduling.k8s.io/v1alpha1=*"
+  #   mutate:
+  #     patchStrategicMerge:
+  #       spec:
+  #         kubeadmConfigSpec:
+  #           clusterConfiguration:
+  #             apiServer:
+  #               extraArgs:
+  #                 runtime-config: "{{ join(',', ['api/all=true', 'scheduling.k8s.io/v1alpha1=true', request.object.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.\"runtime-config\"]) }}"
+
+
+  # - name: kubeadmcontrolplane-merge-featuregates-flags
+  #   match:
+  #     resources:
+  #       kinds:
+  #       - controlplane.cluster.x-k8s.io/v1alpha3/KubeadmControlPlane
+  #       - controlplane.cluster.x-k8s.io/v1alpha4/KubeadmControlPlane
+  #       selector:
+  #         matchLabels:
+  #           cluster.x-k8s.io/watch-filter: capi
+  #   preconditions:
+  #     any:
+  #     - key: "{{request.object.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.\"feature-gates\"}}"
+  #       operator: Equals
+  #       value: ""
+  #     - key: "{{request.object.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.\"feature-gates\"}}"
+  #       operator: NotEquals
+  #       value: "*TTLAfterFinished=*"
+  #   mutate:
+  #     patchStrategicMerge:
+  #       spec:
+  #         kubeadmConfigSpec:
+  #           clusterConfiguration:
+  #             apiServer:
+  #               extraArgs:
+  #                 feature-gates: "{{ join(',', ['TTLAfterFinished=true', request.object.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.\"feature-gates\"]) }}"
+
+  - name: kubeadmcontrolplane-apiserverargs
+    match:
+      resources:
+        kinds:
+        - controlplane.cluster.x-k8s.io/v1alpha3/KubeadmControlPlane
+        - controlplane.cluster.x-k8s.io/v1alpha4/KubeadmControlPlane
+        selector:
+          matchLabels:
+            cluster.x-k8s.io/watch-filter: capi
+    mutate:
+      patchStrategicMerge:
+        spec:
+          kubeadmConfigSpec:
+            clusterConfiguration:
+              apiServer:
+                extraArgs:
+                  +(feature-gates): "TTLAfterFinished=true"
+                  +(runtime-config): "api/all=true,scheduling.k8s.io/v1alpha1=true"


### PR DESCRIPTION
Issue: https://github.com/giantswarm/roadmap/issues/487

Added kubelet and api-server flags to make CAPI installation more in-line with legacy GS offering.

I've added these to the common policies as I'm fairly sure they are relevant for all providers but would be good if someone from each team could confirm for me :) 

### Checklist

- [x] Update changelog in CHANGELOG.md.
