### PR TITLE
Enforce nginx CVE-2021-25742 mitigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added policy to enforce mitigation for nginx CVE-2021-25742 from
+
 ## [0.9.1] - 2021-10-20
 
 ### Fixed

--- a/helm/policies-shared/templates/nginx-disallow-custom-snippets.yaml
+++ b/helm/policies-shared/templates/nginx-disallow-custom-snippets.yaml
@@ -1,0 +1,42 @@
+# THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
+
+# source https://github.com/JimBugwadia/kyverno-policies/blob/c138c43274b8468ae8af904fc4bdd24c07561690/best-practices/nginx-custom-snippets/disallow-custom-snippets.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-ingress-nginx-custom-snippets
+  annotations:
+    policies.kyverno.io/title: Disallow Custom Snippets
+    policies.kyverno.io/category: Best Practice
+    policies.kyverno.io/subject: ConfigMap, Ingress
+    policies.kyverno.io/minversion: 1.4.3
+    policies.kyverno.io/description: >-
+      Users that can create or update ingress objects can use the custom snippets
+      feature to obtain all secrets in the cluster (CVE-2021-25742). This policy
+      disables allow-snippet-annotations in the ingress-nginx configuration and
+      blocks *-snippet annotations on an Ingress.
+      See: https://github.com/kubernetes/ingress-nginx/issues/7837
+spec:
+  validationFailureAction: enforce
+  rules:
+    - name: check-config-map
+      message: "ingress-nginx allow-snippet-annotations must be set to false"
+      match:
+        resources:
+          kinds:
+            - ConfigMap
+      validate:
+        pattern:
+          data:
+            =(allow-snippet-annotations) : "false"
+    - name: check-ingress-annotations
+      message: "ingress-nginx custom snippets are not allowed"
+      match:
+        resources:
+          kinds:
+            - Ingress
+      validate:
+        pattern:
+          metadata:
+            =(annotations):
+              X(*-snippets): "?*"

--- a/helm/policies-shared/templates/nginx-disallow-custom-snippets.yaml
+++ b/helm/policies-shared/templates/nginx-disallow-custom-snippets.yaml
@@ -29,6 +29,16 @@ spec:
         pattern:
           data:
             =(allow-snippet-annotations) : "false"
+    - name: check-config-map-legacy
+      message: "ingress-nginx enable-snippet-directives must be set to false"
+      match:
+        resources:
+          kinds:
+            - ConfigMap
+      validate:
+        pattern:
+          data:
+            =(enable-snippet-directives) : "false"
     - name: check-ingress-annotations
       message: "ingress-nginx custom snippets are not allowed"
       match:

--- a/policies/shared/nginx-disallow-custom-snippets.yaml
+++ b/policies/shared/nginx-disallow-custom-snippets.yaml
@@ -1,0 +1,51 @@
+
+# source https://github.com/JimBugwadia/kyverno-policies/blob/c138c43274b8468ae8af904fc4bdd24c07561690/best-practices/nginx-custom-snippets/disallow-custom-snippets.yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-ingress-nginx-custom-snippets
+  annotations:
+    policies.kyverno.io/title: Disallow Custom Snippets
+    policies.kyverno.io/category: Best Practice
+    policies.kyverno.io/subject: ConfigMap, Ingress
+    policies.kyverno.io/minversion: 1.4.3
+    policies.kyverno.io/description: >-
+      Users that can create or update ingress objects can use the custom snippets
+      feature to obtain all secrets in the cluster (CVE-2021-25742). This policy
+      disables allow-snippet-annotations in the ingress-nginx configuration and
+      blocks *-snippet annotations on an Ingress.
+      See: https://github.com/kubernetes/ingress-nginx/issues/7837
+spec:
+  validationFailureAction: enforce
+  rules:
+    - name: check-config-map
+      message: "ingress-nginx allow-snippet-annotations must be set to false"
+      match:
+        resources:
+          kinds:
+            - ConfigMap
+      validate:
+        pattern:
+          data:
+            =(allow-snippet-annotations) : "false"
+    - name: check-config-map-legacy
+      message: "ingress-nginx enable-snippet-directives must be set to false"
+      match:
+        resources:
+          kinds:
+            - ConfigMap
+      validate:
+        pattern:
+          data:
+            =(enable-snippet-directives) : "false"
+    - name: check-ingress-annotations
+      message: "ingress-nginx custom snippets are not allowed"
+      match:
+        resources:
+          kinds:
+            - Ingress
+      validate:
+        pattern:
+          metadata:
+            =(annotations):
+              X(*-snippets): "?*"


### PR DESCRIPTION
This PR adds a policy enforcing nginx CVE-2021-25742 mitigations from https://github.com/JimBugwadia/kyverno-policies/blob/c138c43274b8468ae8af904fc4bdd24c07561690/best-practices/nginx-custom-snippets/disallow-custom-snippets.yaml

### Checklist

- [x] Update changelog in CHANGELOG.md.
