### PR TITLE
Remove PodSecurityPolicy from enabled admission plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove `PodSecurityPolicy` from the enabled api-server admission plugins.
+
 ## [0.9.1] - 2021-10-20
 
 ### Fixed

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -3,8 +3,10 @@ SHELL:=/usr/bin/env bash
 # If not already set through env
 KUBERNETES_VERSION ?= v1.21.1
 
+##@ Generate
+
 .PHONY: generate
-generate:
+generate: ## Replace variables on Helm manifests.
 	./hack/template.sh
 
 .PHONY: verify

--- a/helm/policies-common/templates/CoreCAPI.yaml
+++ b/helm/policies-common/templates/CoreCAPI.yaml
@@ -255,7 +255,7 @@ spec:
                   # audit-policy-file: "/etc/kubernetes/policies/audit-policy.yaml"
                   # encryption-provider-config: "/etc/kubernetes/encryption/k8s-encryption-config.yaml"
                   service-account-lookup: "true"
-                  enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,PodSecurityPolicy,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook"
+                  enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook"
                   kubelet-preferred-address-types: "InternalIP"
                   +(profiling): "false"
                   +(tls-cipher-suites): "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"

--- a/policies/common/CoreCAPI.yaml
+++ b/policies/common/CoreCAPI.yaml
@@ -254,7 +254,7 @@ spec:
                   # audit-policy-file: "/etc/kubernetes/policies/audit-policy.yaml"
                   # encryption-provider-config: "/etc/kubernetes/encryption/k8s-encryption-config.yaml"
                   service-account-lookup: "true"
-                  enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,PodSecurityPolicy,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook"
+                  enable-admission-plugins: "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook"
                   kubelet-preferred-address-types: "InternalIP"
                   +(profiling): "false"
                   +(tls-cipher-suites): "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"


### PR DESCRIPTION
CAPI installs coredns, but it doesn't apply PSP/RBAC that would allow coredns to run when PSPs are enabled. So let's disable PSP for the first alpha CAPI release.

### Checklist

- [X] Update changelog in CHANGELOG.md.
