### PR TITLE
Add help to other make commands

### DIFF
--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -14,11 +14,13 @@ verify:
 	@$(MAKE) generate
 	git diff --exit-code
 
+##@ Test
+
 .PHONY: clean
-clean:
+clean: ## Delete test manifests from kind cluster.
 	./hack/cleanup-local.sh
 
 .PHONY: setup
-setup:
+setup: ## Create kind cluster with CAPI and Kyverno.
 	@$(MAKE) generate
 	./hack/setup-local.sh $(KUBERNETES_VERSION)


### PR DESCRIPTION
```
$ make help

Usage:
  make <target>

General
  help                  Display this help.

Generate
  generate              Replace variables on Helm manifests.

Test
  clean                 Delete test manifests from kind cluster.
  setup                 Create kind cluster with CAPI and Kyverno.

App
  lint-chart            Runs ct against the default chart.
```