### PR TITLE
Relax v20 name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dabs.sh
+dats.sh
 kube.config
 build/
 logs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Apply policies to v20 even when v20 contains suffixes in its name.
+
 ## [0.9.2] - 2021-10-26
 
 ### Changed

--- a/helm/policies-aws/templates/AWSCAPI.yaml
+++ b/helm/policies-aws/templates/AWSCAPI.yaml
@@ -35,7 +35,7 @@ spec:
       any:
       - key: "{{ `{{` }} releaseVersion {{ `}}` }}"
         operator: Equals
-        value: "20.0.0"
+        value: "20.0.0*"
     mutate:
       patchStrategicMerge:
         metadata:

--- a/helm/policies-azure/templates/AzureCAPI.yaml
+++ b/helm/policies-azure/templates/AzureCAPI.yaml
@@ -28,7 +28,7 @@ spec:
       any:
       - key: "{{ `{{` }} releaseVersion {{ `}}` }}"
         operator: Equals
-        value: "20.0.0"
+        value: "20.0.0*"
     mutate:
       patchStrategicMerge:
         metadata:

--- a/helm/policies-common/templates/CoreCAPI.yaml
+++ b/helm/policies-common/templates/CoreCAPI.yaml
@@ -21,7 +21,7 @@ spec:
       any:
       - key: "{{ `{{` }} request.object.metadata.labels.\"release.giantswarm.io/version\" {{ `}}` }}"
         operator: Equals
-        value: "20.0.0"
+        value: "20.0.0*"
     mutate:
       patchStrategicMerge:
         metadata:
@@ -102,7 +102,7 @@ spec:
       any:
       - key: "{{ `{{` }} releaseVersion {{ `}}` }}"
         operator: Equals
-        value: "20.0.0"
+        value: "20.0.0*"
     mutate:
       patchStrategicMerge:
         metadata:

--- a/helm/policies-vsphere/templates/VSphereCAPI.yaml
+++ b/helm/policies-vsphere/templates/VSphereCAPI.yaml
@@ -22,7 +22,7 @@ spec:
       any:
       - key: "{{ `{{` }} releaseVersion {{ `}}` }}"
         operator: Equals
-        value: "20.0.0"
+        value: "20.0.0*"
     mutate:
       patchStrategicMerge:
         metadata:

--- a/helm/policies-vsphere/tests/ats/test_vsphere_default.py
+++ b/helm/policies-vsphere/tests/ats/test_vsphere_default.py
@@ -25,5 +25,5 @@ def test_cluster_vsphere_policy(release) -> None:
 
     :param release: Release CR which is used by the Cluster.
     """
-    assert release['metadata']['name'] == "v20.0.0"
+    assert release['metadata']['name'].startswith("v20.0.0")
 

--- a/helm/tests/ensure.py
+++ b/helm/tests/ensure.py
@@ -15,7 +15,7 @@ service_monitor_name = "test-service-monitor"
 silence_name = "test-silence"
 cluster_name = "test-cluster"
 machinepool_name = "mp0"
-release_version = "20.0.0"
+release_version = "20.0.0-alpha1"
 cluster_apps_operator_version = "2.0.0"
 watch_label = "capi"
 

--- a/policies/aws/AWSCAPI.yaml
+++ b/policies/aws/AWSCAPI.yaml
@@ -34,7 +34,7 @@ spec:
       any:
       - key: "{{ releaseVersion }}"
         operator: Equals
-        value: "20.0.0"
+        value: "20.0.0*"
     mutate:
       patchStrategicMerge:
         metadata:

--- a/policies/azure/AzureCAPI.yaml
+++ b/policies/azure/AzureCAPI.yaml
@@ -27,7 +27,7 @@ spec:
       any:
       - key: "{{ releaseVersion }}"
         operator: Equals
-        value: "20.0.0"
+        value: "20.0.0*"
     mutate:
       patchStrategicMerge:
         metadata:

--- a/policies/common/CoreCAPI.yaml
+++ b/policies/common/CoreCAPI.yaml
@@ -20,7 +20,7 @@ spec:
       any:
       - key: "{{ request.object.metadata.labels.\"release.giantswarm.io/version\" }}"
         operator: Equals
-        value: "20.0.0"
+        value: "20.0.0*"
     mutate:
       patchStrategicMerge:
         metadata:
@@ -101,7 +101,7 @@ spec:
       any:
       - key: "{{ releaseVersion }}"
         operator: Equals
-        value: "20.0.0"
+        value: "20.0.0*"
     mutate:
       patchStrategicMerge:
         metadata:

--- a/policies/vsphere/VSphereCAPI.yaml
+++ b/policies/vsphere/VSphereCAPI.yaml
@@ -21,7 +21,7 @@ spec:
       any:
       - key: "{{ releaseVersion }}"
         operator: Equals
-        value: "20.0.0"
+        value: "20.0.0*"
     mutate:
       patchStrategicMerge:
         metadata:


### PR DESCRIPTION
SIG-Product has decided that the first GS CAPI release will be called `v20.0.0-alpha`. If we want to keep applying same policies we need to use the new name. And anticipating that it could be renamed in the future, I relaxed the check so that everything works as long as the release name starts with `v20.0.0`.

### Checklist

- [X] Update changelog in CHANGELOG.md.
