### PR TITLE
Append extraVolumes instead of force set them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Tilt support.
 
+### Changed
+
+- The api-server `extraVolumes` are appended instead of over writing the existing ones.
+
 ## [0.10.0] - 2021-11-19
 
 ### Changed

--- a/helm/policies-common/templates/CoreCAPI.yaml
+++ b/helm/policies-common/templates/CoreCAPI.yaml
@@ -261,14 +261,6 @@ spec:
                   +(tls-cipher-suites): "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
                   +(runtime-config): "api/all=true,scheduling.k8s.io/v1alpha1=true"
                   +(feature-gates): "TTLAfterFinished=true"
-                extraVolumes:
-                  - hostPath: /etc/kubernetes/policies
-                    mountPath: /etc/kubernetes/policies
-                    name: audit-policy
-                    readOnly: true
-                  - hostPath: /var/log/apiserver
-                    mountPath: /var/log/apiserver
-                    name: apiserver-log
             initConfiguration:
               nodeRegistration:
                 kubeletExtraArgs:
@@ -276,6 +268,46 @@ spec:
                   node-ip: "{{ `{{` }} dictionary.data.nodeip {{ `}}` }}"
                   +(v): "2"
                   +(image-pull-progress-deadline): "{{ .Values.Installation.V1.Guest.Kubernetes.Kubelet.ImagePullProgressDeadline }}"
+
+  - name: kubeadmcontrolplane-extravolumes-apiserver-policies
+    match:
+      resources:
+        kinds:
+          - controlplane.cluster.x-k8s.io/v1alpha3/KubeadmControlPlane
+          - controlplane.cluster.x-k8s.io/v1alpha4/KubeadmControlPlane
+        selector:
+          matchLabels:
+            cluster.x-k8s.io/watch-filter: capi
+    preconditions:
+      any:
+        - key: "/etc/kubernetes/policies"
+          operator: NotIn
+          value: "{{ `{{` }}request.object.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraVolumes[].hostPath{{ `}}` }}"
+    mutate:
+      patchesJson6902: |-
+        - op: add
+          path: "/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes/-"
+          value: {"hostPath":"/etc/kubernetes/policies","mountPath":"/etc/kubernetes/policies","readOnly":true,"name":"audit-policy"}
+
+  - name: kubeadmcontrolplane-extravolumes-apiserver-logs
+    match:
+      resources:
+        kinds:
+          - controlplane.cluster.x-k8s.io/v1alpha3/KubeadmControlPlane
+          - controlplane.cluster.x-k8s.io/v1alpha4/KubeadmControlPlane
+        selector:
+          matchLabels:
+            cluster.x-k8s.io/watch-filter: capi
+    preconditions:
+      any:
+        - key: "/var/log/apiserver"
+          operator: NotIn
+          value: "{{ `{{` }}request.object.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraVolumes[].hostPath{{ `}}` }}"
+    mutate:
+      patchesJson6902: |-
+        - op: add
+          path: "/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes/-"
+          value: {"hostPath":"/var/log/apiserver","mountPath":"/var/log/apiserver","name":"apiserver-log"}
 
   - name: kubeadmcontrolplane-merge-runtimeconfig-apiall-flags
     match:

--- a/helm/policies-common/tests/ats/test_common_default.py
+++ b/helm/policies-common/tests/ats/test_common_default.py
@@ -125,6 +125,13 @@ def test_kubeadmcontrolplane_policy(kubeadm_control_plane) -> None:
     assert kubeadm_control_plane['spec']['kubeadmConfigSpec']['initConfiguration']['nodeRegistration']['kubeletExtraArgs']['node-ip'] == '{{ ds.meta_data.local_ipv4 }}'
     assert kubeadm_control_plane['spec']['kubeadmConfigSpec']['clusterConfiguration']['apiServer']['extraArgs']['feature-gates'] == 'TTLAfterFinished=true'
     assert kubeadm_control_plane['spec']['kubeadmConfigSpec']['clusterConfiguration']['apiServer']['extraArgs']['runtime-config'] == 'api/all=true,scheduling.k8s.io/v1alpha1=true'
+    # Assert that we don't lose extraArgs or extraVolumes that were already set.
+    assert kubeadm_control_plane['spec']['kubeadmConfigSpec']['clusterConfiguration']['apiServer']['extraArgs']['cloud-provider'] == 'azure'
+    hasExistingExtraVolume = False
+    for volume in kubeadm_control_plane['spec']['kubeadmConfigSpec']['clusterConfiguration']['apiServer']['extraVolumes']:
+        if volume['hostPath'] == "/etc/kubernetes/azure.json":
+            hasExistingExtraVolume = True
+    assert hasExistingExtraVolume == True
 
 @pytest.mark.smoke
 def test_kubeadmcontrolplane_auditpolicy(kubeadm_control_plane) -> None:

--- a/helm/tests/ensure.py
+++ b/helm/tests/ensure.py
@@ -742,6 +742,15 @@ def kubeadm_control_plane(kubernetes_cluster):
         spec:
           kubeadmConfigSpec:
             clusterConfiguration:
+              apiServer:
+                extraArgs:
+                  cloud-config: /etc/kubernetes/azure.json
+                  cloud-provider: azure
+                extraVolumes:
+                - hostPath: /etc/kubernetes/azure.json
+                  mountPath: /etc/kubernetes/azure.json
+                  name: cloud-config
+                  readOnly: true
               controllerManager:
                 extraArgs:
                   allocate-node-cidrs: "false"

--- a/policies/common/CoreCAPI.yaml
+++ b/policies/common/CoreCAPI.yaml
@@ -260,14 +260,6 @@ spec:
                   +(tls-cipher-suites): "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
                   +(runtime-config): "api/all=true,scheduling.k8s.io/v1alpha1=true"
                   +(feature-gates): "TTLAfterFinished=true"
-                extraVolumes:
-                  - hostPath: /etc/kubernetes/policies
-                    mountPath: /etc/kubernetes/policies
-                    name: audit-policy
-                    readOnly: true
-                  - hostPath: /var/log/apiserver
-                    mountPath: /var/log/apiserver
-                    name: apiserver-log
             initConfiguration:
               nodeRegistration:
                 kubeletExtraArgs:
@@ -275,6 +267,46 @@ spec:
                   node-ip: "{{ dictionary.data.nodeip }}"
                   +(v): "2"
                   +(image-pull-progress-deadline): "[[ .Values.Installation.V1.Guest.Kubernetes.Kubelet.ImagePullProgressDeadline ]]"
+
+  - name: kubeadmcontrolplane-extravolumes-apiserver-policies
+    match:
+      resources:
+        kinds:
+          - controlplane.cluster.x-k8s.io/v1alpha3/KubeadmControlPlane
+          - controlplane.cluster.x-k8s.io/v1alpha4/KubeadmControlPlane
+        selector:
+          matchLabels:
+            cluster.x-k8s.io/watch-filter: capi
+    preconditions:
+      any:
+        - key: "/etc/kubernetes/policies"
+          operator: NotIn
+          value: "{{request.object.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraVolumes[].hostPath}}"
+    mutate:
+      patchesJson6902: |-
+        - op: add
+          path: "/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes/-"
+          value: {"hostPath":"/etc/kubernetes/policies","mountPath":"/etc/kubernetes/policies","readOnly":true,"name":"audit-policy"}
+
+  - name: kubeadmcontrolplane-extravolumes-apiserver-logs
+    match:
+      resources:
+        kinds:
+          - controlplane.cluster.x-k8s.io/v1alpha3/KubeadmControlPlane
+          - controlplane.cluster.x-k8s.io/v1alpha4/KubeadmControlPlane
+        selector:
+          matchLabels:
+            cluster.x-k8s.io/watch-filter: capi
+    preconditions:
+      any:
+        - key: "/var/log/apiserver"
+          operator: NotIn
+          value: "{{request.object.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraVolumes[].hostPath}}"
+    mutate:
+      patchesJson6902: |-
+        - op: add
+          path: "/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes/-"
+          value: {"hostPath":"/var/log/apiserver","mountPath":"/var/log/apiserver","name":"apiserver-log"}
 
   - name: kubeadmcontrolplane-merge-runtimeconfig-apiall-flags
     match:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/572

The `api-server` `extraVolumes` on the `KubeadmControlPlane` resource are being set from kyverno. But this is overwriting whatever `extraVolumes` were set in the first place. We have to have another one to mount the cloud configuration for the cloud provider. We are currently [setting that in the `kubectl-gs` template](https://github.com/giantswarm/kubectl-gs/blob/2a0b07b28dbddce25ab11606f57bd76e408258f3/cmd/template/cluster/provider/templates/azure/kubeadm_control_plane.yaml.tmpl#L16-L23), but it gets overwritten by kyverno. This currently breaks cluster creation.

With these changes we append these `extraVolumes` to whatever is already there.

### Checklist

- [X] Update changelog in CHANGELOG.md.
