### PR TITLE
Add CAPO policy to default the MachineDeployment failure domain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,20 +88,23 @@ jobs:
           command: |
             make dabs
       - run-ats:
-          chart_archive_prefix: "policies-common"
-          tests_dir: "helm/policies-common/tests/ats"
-      - run-ats:
           chart_archive_prefix: "policies-aws"
           tests_dir: "helm/policies-aws/tests/ats"
       - run-ats:
           chart_archive_prefix: "policies-azure"
           tests_dir: "helm/policies-azure/tests/ats"
       - run-ats:
-          chart_archive_prefix: "policies-vsphere"
-          tests_dir: "helm/policies-vsphere/tests/ats"
+          chart_archive_prefix: "policies-common"
+          tests_dir: "helm/policies-common/tests/ats"
+      - run-ats:
+          chart_archive_prefix: "policies-openstack"
+          tests_dir: "helm/policies-openstack/tests/ats"
       - run-ats:
           chart_archive_prefix: "policies-shared"
           tests_dir: "helm/policies-shared/tests/ats"
+      - run-ats:
+          chart_archive_prefix: "policies-vsphere"
+          tests_dir: "helm/policies-vsphere/tests/ats"
       - run:
           name: Export kind logs
           when: always
@@ -179,6 +182,22 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      # Openstack
+      - architect/push-to-app-catalog:
+          name: push-policies-openstack-to-catalog
+          app_catalog: control-plane-test-catalog
+          app_catalog_test: control-plane-test-catalog
+          attach_workspace: true
+          chart: policies-openstack
+          context: "architect"
+          explicit_allow_chart_name_mismatch: true
+          on_tag: false
+          requires:
+            - test-policies
+          # Needed to trigger job also on git tag.
+          filters:
+            tags:
+              only: /^v.*/
       # VSphere
       - architect/push-to-app-catalog:
           name: push-policies-vsphere-to-catalog
@@ -246,6 +265,34 @@ workflows:
           app_name: "policies-shared"
           app_namespace: "giantswarm"
           app_collection_repo: "kvm-app-collection"
+          requires:
+            - push-policies-shared-to-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          name: push-policies-openstack-to-openstack-app-collection
+          context: architect
+          app_name: "policies-openstack"
+          app_namespace: "giantswarm"
+          app_collection_repo: "openstack-app-collection"
+          requires:
+            - push-policies-openstack-to-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          name: push-policies-shared-to-openstack-app-collection
+          context: architect
+          app_name: "policies-openstack"
+          app_namespace: "giantswarm"
+          app_collection_repo: "openstack-app-collection"
           requires:
             - push-policies-shared-to-catalog
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ workflows:
       - architect/push-to-app-collection:
           name: push-policies-shared-to-openstack-app-collection
           context: architect
-          app_name: "policies-openstack"
+          app_name: "policies-shared"
           app_namespace: "giantswarm"
           app_collection_repo: "openstack-app-collection"
           requires:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `policies-openstack` for OpenStack-specific policies.
+- Add policy for OpenStack which defaults `failureDomain` based on `MachineDeployment`
+  request's `machine-deployment.giantswarm.io/failure-domain` label.
+
 ## [0.12.0] - 2021-12-09
 
 ### Added

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -44,8 +44,9 @@ kind-get-kubeconfig:
 
 .PHONY: dabs
 dabs: generate
-	dabs.sh --generate-metadata --chart-dir helm/policies-common
 	dabs.sh --generate-metadata --chart-dir helm/policies-aws
 	dabs.sh --generate-metadata --chart-dir helm/policies-azure
-	dabs.sh --generate-metadata --chart-dir helm/policies-vsphere
+	dabs.sh --generate-metadata --chart-dir helm/policies-common
+	dabs.sh --generate-metadata --chart-dir helm/policies-openstack
 	dabs.sh --generate-metadata --chart-dir helm/policies-shared
+	dabs.sh --generate-metadata --chart-dir helm/policies-vsphere

--- a/hack/template.sh
+++ b/hack/template.sh
@@ -29,7 +29,7 @@ replace_all () {
   mv $filename.modified $filename
 }
 
-for i in aws azure common shared vsphere; do
+for i in aws azure common shared openstack vsphere; do
   mkdir -p $(pwd)/helm/policies-$i/templates
 
   cp -a $(pwd)/policies/$i/. $(pwd)/helm/policies-$i/templates

--- a/helm/policies-openstack/Chart.yaml
+++ b/helm/policies-openstack/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+appVersion: master
+description: Giant Swarm Kyverno policies for OpenStack.
+home: https://github.com/giantswarm/kyverno-policies
+name: policies-openstack
+annotations:
+  application.giantswarm.io/team: "honeybadger"
+  config.giantswarm.io/version: 1.x.x
+version: [[ .Version ]]

--- a/helm/policies-openstack/templates/CoreCAPI.yaml
+++ b/helm/policies-openstack/templates/CoreCAPI.yaml
@@ -1,0 +1,20 @@
+# THIS FILE IS GENERATED WITH 'make generate' - DO NOT EDIT MANUALLY
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: capo-policy
+spec:
+  background: false
+  rules:
+  - name: machine-set-failure-domain
+    match:
+      resources:
+        kinds:
+        - cluster.x-k8s.io/v1alpha4/MachineSet
+        - cluster.x-k8s.io/v1beta1/MachineSet
+    mutate:
+      patchStrategicMerge:
+        spec:
+          template:
+            spec:
+              +(failureDomain): "{{ `{{` }} request.object.spec.template.metadata.labels.\"machine-deployment.giantswarm.io/failure-domain\" {{ `}}` }}"

--- a/helm/policies-openstack/tests/ats/Pipfile
+++ b/helm/policies-openstack/tests/ats/Pipfile
@@ -1,0 +1,20 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+pre-commit = "==2.11.1"
+setuptools = "==54.0.0"
+
+[packages]
+pytest-kube = {git = "https://github.com/giantswarm/pytest-kube.git", editable = false, ref = "kubectl"}
+pytest = "==6.2.2"
+pykube-ng = "==21.3.0"
+pyyaml = "==5.4.1"
+pytest-rerunfailures = "==9.1.1"
+requests = "==2.25.1"
+setuptools = "==54.0.0"
+
+[requires]
+python_version = "3.8"

--- a/helm/policies-openstack/tests/ats/Pipfile.lock
+++ b/helm/policies-openstack/tests/ats/Pipfile.lock
@@ -1,0 +1,301 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "87dba5ed4e923871f87243a84abed06eb5cd723acad801cce679f8718cad8f64"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.2.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
+                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+            ],
+            "version": "==2021.10.8"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.0.0"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.10"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
+                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==21.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.13.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.10.0"
+        },
+        "pykube-ng": {
+            "hashes": [
+                "sha256:06d73e639d4c63979798042247330e6b9e7072e4a2be84a0ea4793e633787970",
+                "sha256:d0824fab6b5c1f25ca5d4b348a9556545603d1ff9251e126fd4008a34e142dc3"
+            ],
+            "index": "pypi",
+            "version": "==21.3.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:9d1edf9e7d0b84d72ea3dbcdfd22b35fb543a5e8f2a60092dd578936bf63d7f9",
+                "sha256:b574b57423e818210672e07ca1fa90aaf194a4f63f3ab909a2c67ebb22913839"
+            ],
+            "index": "pypi",
+            "version": "==6.2.2"
+        },
+        "pytest-kube": {
+            "editable": false,
+            "git": "https://github.com/giantswarm/pytest-kube.git",
+            "ref": "5c18f89596d24a4fa81c47f26c3a33df3dcbc1a5"
+        },
+        "pytest-rerunfailures": {
+            "hashes": [
+                "sha256:1cb11a17fc121b3918414eb5eaf314ee325f2e693ac7cb3f6abf7560790827f2",
+                "sha256:2eb7d0ad651761fbe80e064b0fd415cf6730cdbc53c16a145fd84b66143e609f"
+            ],
+            "index": "pypi",
+            "version": "==9.1.1"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc",
+                "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247",
+                "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6",
+                "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"
+            ],
+            "index": "pypi",
+            "version": "==5.4.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
+            ],
+            "index": "pypi",
+            "version": "==2.25.1"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
+                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.7"
+        }
+    },
+    "develop": {
+        "backports.entry-points-selectable": {
+            "hashes": [
+                "sha256:988468260ec1c196dab6ae1149260e2f5472c9110334e5d51adcb77867361f6a",
+                "sha256:a6d9a871cde5e15b4c4a53e3d43ba890cc6861ec1332c9c2428c92f977192acc"
+            ],
+            "markers": "python_version >= '2.7'",
+            "version": "==1.1.0"
+        },
+        "cfgv": {
+            "hashes": [
+                "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426",
+                "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"
+            ],
+            "markers": "python_full_version >= '3.6.1'",
+            "version": "==3.3.1"
+        },
+        "distlib": {
+            "hashes": [
+                "sha256:c8b54e8454e5bf6237cc84c20e8264c3e991e824ef27e8f1e81049867d861e31",
+                "sha256:d982d0751ff6eaaab5e2ec8e691d949ee80eddf01a62eaa96ddb11531fe16b05"
+            ],
+            "version": "==0.3.3"
+        },
+        "filelock": {
+            "hashes": [
+                "sha256:2b5eb3589e7fdda14599e7eb1a50e09b4cc14f34ed98b8ba56d33bfaafcbef2f",
+                "sha256:34a9f35f95c441e7b38209775d6e0337f9a3759f3565f6c5798f19618527c76f"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.3.1"
+        },
+        "identify": {
+            "hashes": [
+                "sha256:d1e82c83d063571bb88087676f81261a4eae913c492dafde184067c584bc7c05",
+                "sha256:fd08c97f23ceee72784081f1ce5125c8f53a02d3f2716dde79a6ab8f1039fea5"
+            ],
+            "markers": "python_full_version >= '3.6.1'",
+            "version": "==2.3.0"
+        },
+        "nodeenv": {
+            "hashes": [
+                "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b",
+                "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"
+            ],
+            "version": "==1.6.0"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2",
+                "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.4.0"
+        },
+        "pre-commit": {
+            "hashes": [
+                "sha256:94c82f1bf5899d56edb1d926732f4e75a7df29a0c8c092559c77420c9d62428b",
+                "sha256:de55c5c72ce80d79106e48beb1b54104d16495ce7f95b0c7b13d4784193a00af"
+            ],
+            "index": "pypi",
+            "version": "==2.11.1"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc",
+                "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247",
+                "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6",
+                "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"
+            ],
+            "index": "pypi",
+            "version": "==5.4.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
+        },
+        "virtualenv": {
+            "hashes": [
+                "sha256:10062e34c204b5e4ec5f62e6ef2473f8ba76513a9a617e873f1f8fb4a519d300",
+                "sha256:bcc17f0b3a29670dd777d6f0755a4c04f28815395bca279cdcb213b97199a6b8"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==20.8.1"
+        }
+    }
+}

--- a/helm/policies-openstack/tests/ats/test_openstack_default.py
+++ b/helm/policies-openstack/tests/ats/test_openstack_default.py
@@ -1,0 +1,29 @@
+import sys
+sys.path.append('../../../tests')
+
+import yaml
+from functools import partial
+import time
+import random
+import string
+import ensure
+from textwrap import dedent
+
+from ensure import release
+
+import pytest
+from pytest_kube import forward_requests, wait_for_rollout, app_template
+
+import logging
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.mark.smoke
+def test_cluster_openstack_policy(release) -> None:
+    """
+    test_cluster_policy tests defaulting of a Cluster where all required values are empty strings.
+
+    :param release: Release CR which is used by the Cluster.
+    """
+    assert release['metadata']['name'].startswith("v20.0.0")
+

--- a/helm/policies-openstack/values.yaml
+++ b/helm/policies-openstack/values.yaml
@@ -1,0 +1,1 @@
+failureDomain: ""

--- a/policies/openstack/CoreCAPI.yaml
+++ b/policies/openstack/CoreCAPI.yaml
@@ -1,0 +1,19 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: capo-policy
+spec:
+  background: false
+  rules:
+  - name: machine-set-failure-domain
+    match:
+      resources:
+        kinds:
+        - cluster.x-k8s.io/v1alpha4/MachineSet
+        - cluster.x-k8s.io/v1beta1/MachineSet
+    mutate:
+      patchStrategicMerge:
+        spec:
+          template:
+            spec:
+              +(failureDomain): "{{ request.object.spec.template.metadata.labels.\"machine-deployment.giantswarm.io/failure-domain\" }}"


### PR DESCRIPTION
`failureDomain` is required for `MachineDeployment`s in OpenStack. Using [ClusterTopology](https://cluster-api.sigs.k8s.io/developer/architecture/controllers/cluster-topology.html) the `failureDomain` cannot currently be specified for a machine deployment. [A PR was just merged to address this](https://github.com/kubernetes-sigs/cluster-api/pull/5850) which should be released in CAPI v1.1, but it's not released yet.

This shouldn't affect existing CAPO cluster creation (`kubectl-gs template cluster`) as the value will only be set if it isn't specified.

This PR also adds the CAPO policies chart and pushes it (and `policies-shared`) to the OpenStack app collection.

### Checklist

- [x] Update changelog in CHANGELOG.md.
