### PR TITLE
Bump ubuntu version in machine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,8 @@ jobs:
             make verify
 
   validate:
-    machine: true
+    machine:
+      image: ubuntu-2004:202010-01
     environment:
       KYVERNO_VERSION: v1.5.0-rc3
     steps:
@@ -52,7 +53,8 @@ jobs:
             kyverno validate ./policies
 
   test-policies:
-    machine: true
+    machine:
+      image: ubuntu-2004:202010-01
     environment:
       KIND_VERSION: v0.11.1
       KUBERNETES_VERSION: v1.21.1


### PR DESCRIPTION
Circle deprecated old machine version, this PR sets the default ubuntu version in circle config

### Checklist

- [ ] Update changelog in CHANGELOG.md.
