### PR TITLE
Remove app collections from circleci configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,19 +207,6 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
-
-      - architect/push-to-app-collection:
-          name: push-kyverno-policies-to-vmware-app-collection
-          context: "architect"
-          app_name: "kyverno-policies"
-          app_collection_repo: "vmware-app-collection"
-          requires:
-            - push-kyverno-policies-to-control-plane-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
       - architect/push-to-app-collection:
           name: push-kyverno-policies-to-cloud-director-app-collection
           context: "architect"
@@ -233,37 +220,11 @@ workflows:
             tags:
               only: /^v.*/
       - architect/push-to-app-collection:
-          name: push-kyverno-policies-to-capz-app-collection
-          context: architect
-          app_name: "kyverno-policies"
-          app_namespace: "giantswarm"
-          app_collection_repo: "capz-app-collection"
-          requires:
-            - push-kyverno-policies-to-control-plane-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-      - architect/push-to-app-collection:
           name: push-kyverno-policies-to-gcp-app-collection
           context: architect
           app_name: "kyverno-policies"
           app_namespace: "giantswarm"
           app_collection_repo: "gcp-app-collection"
-          requires:
-            - push-kyverno-policies-to-control-plane-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-      - architect/push-to-app-collection:
-          name: push-kyverno-policies-to-vsphere-app-collection
-          context: architect
-          app_name: "kyverno-policies"
-          app_namespace: "giantswarm"
-          app_collection_repo: "vsphere-app-collection"
           requires:
             - push-kyverno-policies-to-control-plane-catalog
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,63 +168,11 @@ workflows:
             tags:
               only: /^v.*/
       - architect/push-to-app-collection:
-          name: push-kyverno-policies-to-capa-app-collection
-          context: architect
-          app_name: "kyverno-policies"
-          app_namespace: "giantswarm"
-          app_collection_repo: "capa-app-collection"
-          requires:
-            - push-kyverno-policies-to-control-plane-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-      - architect/push-to-app-collection:
           name: push-kyverno-policies-to-azure-app-collection
           context: architect
           app_name: "kyverno-policies"
           app_namespace: "giantswarm"
           app_collection_repo: "azure-app-collection"
-          requires:
-            - push-kyverno-policies-to-control-plane-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-collection:
-          name: push-kyverno-policies-to-kvm-app-collection
-          context: architect
-          app_name: "kyverno-policies"
-          app_namespace: "giantswarm"
-          app_collection_repo: "kvm-app-collection"
-          requires:
-            - push-kyverno-policies-to-control-plane-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-      - architect/push-to-app-collection:
-          name: push-kyverno-policies-to-cloud-director-app-collection
-          context: "architect"
-          app_name: "kyverno-policies"
-          app_collection_repo: "cloud-director-app-collection"
-          requires:
-            - push-kyverno-policies-to-control-plane-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-      - architect/push-to-app-collection:
-          name: push-kyverno-policies-to-gcp-app-collection
-          context: architect
-          app_name: "kyverno-policies"
-          app_namespace: "giantswarm"
-          app_collection_repo: "gcp-app-collection"
           requires:
             - push-kyverno-policies-to-control-plane-catalog
           filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Don't push to vsphere-app-collection, capz-app-collection and cloud-director-app-collection. We started to consume kyverno-policies from security-bundle.
+- Don't push to vsphere-app-collection, capz-app-collection, capa-app-collection or cloud-director-app-collection. We started to consume kyverno-policies from security-bundle.
 
 ## [0.20.2] - 2023-12-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Don't push to vsphere-app-collection, cloud-director-app-collection and cloud-director-app-collection. We started to consume kyverno-policies from security-bundle.
+- Don't push to vsphere-app-collection, capz-app-collection and cloud-director-app-collection. We started to consume kyverno-policies from security-bundle.
 
 ## [0.20.2] - 2023-12-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Don't push to vsphere-app-collection, cloud-director-app-collection and cloud-director-app-collection. We started to consume kyverno-app from security-bundle.
+
 ## [0.20.2] - 2023-12-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Don't push to vsphere-app-collection, cloud-director-app-collection and cloud-director-app-collection. We started to consume kyverno-app from security-bundle.
+- Don't push to vsphere-app-collection, cloud-director-app-collection and cloud-director-app-collection. We started to consume kyverno-policies from security-bundle.
 
 ## [0.20.2] - 2023-12-06
 


### PR DESCRIPTION
We remove kyverno-policies from vsphere, cloud-director and capz collections. We consume it from security-bundle for MCs too.

See:
- https://github.com/giantswarm/vsphere-app-collection/pull/74/files
- https://github.com/giantswarm/capz-app-collection/pull/75/files
- https://github.com/giantswarm/cloud-director-app-collection/pull/75/files

### Checklist

- [ ] Update changelog in CHANGELOG.md.
