### PR TITLE
Inherit secrets to update-chart workflow

### DIFF
--- a/.github/workflows/sync-from-upstream.yaml
+++ b/.github/workflows/sync-from-upstream.yaml
@@ -33,5 +33,6 @@ jobs:
   call-update-chart:
     uses: ./.github/workflows/zz_generated.update_chart.yaml
     needs: sync-app-with-fork
+    secrets: inherit
     with:
       branch: 'main#update-chart'


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/31056

This PR allows to inherit the repository secrets to the update-chart workflow