### PR TITLE
Update CircleCI runner instance versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ commands:
 jobs:
   verify:
     docker:
-      - image: cimg/base:2022.11
+      - image: cimg/base:current-22.04
     steps:
       - checkout
       - run:
@@ -38,7 +38,7 @@ jobs:
 
   validate:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2204:current
     environment:
       KYVERNO_VERSION: v1.5.0-rc3
     steps:
@@ -54,7 +54,7 @@ jobs:
 
   test-policies:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2204:current
     environment:
       KIND_VERSION: v0.17.0
       KUBERNETES_VERSION: v1.24.7


### PR DESCRIPTION
Tests have been failing because the old runner versions aren't available anymore.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
