### PR TITLE
feat: Add optional failurePolicy to restrict-external-ips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add optional `failurePolicy` field to the `restrict-external-ips` supplemental policy so it can be set to `Ignore` (fail open). This prevents a transient Kyverno outage from blocking all Service writes cluster-wide while the policy is in `Audit` mode.
+- Allow overriding the `failurePolicy` of the `restrict-external-ips` supplemental policy.
 
 ## [0.26.0] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add optional `failurePolicy` field to the `restrict-external-ips` supplemental policy so it can be set to `Ignore` (fail open). This prevents a transient Kyverno outage from blocking all Service writes cluster-wide while the policy is in `Audit` mode.
+
 ## [0.26.0] - 2026-07-01
 
 ### Added

--- a/helm/kyverno-policies/templates/supplemental/restrict-external-ips.yaml
+++ b/helm/kyverno-policies/templates/supplemental/restrict-external-ips.yaml
@@ -17,6 +17,9 @@ metadata:
       See: https://github.com/kyverno/kyverno/issues/1367. This policy validates
       that the `externalIPs` field is not set on a Service.      
 spec:
+  {{- with (get .Values.supplementalSecurityPolicies.policies $name).failurePolicy }}
+  failurePolicy: {{ . }}
+  {{- end }}
   validationFailureAction: {{ (get .Values.supplementalSecurityPolicies.policies $name).mode }}
   background: true
   rules:

--- a/helm/kyverno-policies/values.schema.json
+++ b/helm/kyverno-policies/values.schema.json
@@ -191,6 +191,9 @@
                                 "enabled": {
                                     "type": "boolean"
                                 },
+                                "failurePolicy": {
+                                    "type": "string"
+                                },
                                 "mode": {
                                     "type": "string"
                                 }

--- a/helm/kyverno-policies/values.yaml
+++ b/helm/kyverno-policies/values.yaml
@@ -83,12 +83,8 @@ supplementalSecurityPolicies:
     restrict-external-ips:
       enabled: true
       mode: Audit
-      # failurePolicy controls how the admission webhook behaves when Kyverno is
-      # unreachable. Because this policy matches Services (writes to which include
-      # unrelated controllers such as kube-vip's LoadBalancer bookkeeping), leaving
-      # it at the Kyverno default of "Fail" means a transient Kyverno outage blocks
-      # all Service writes cluster-wide. Set to "Ignore" to fail open. Unset keeps
-      # the Kyverno default ("Fail"). Only meaningful to change while mode is Audit.
+      # "Ignore" fails open if Kyverno is down. Unset keeps
+      # the Kyverno default ("Fail").
       # failurePolicy: Ignore
 
     # restrict-sa-automount-sa-token ensures that ServiceAccounts do not automatically mount ServiceAccount tokens.

--- a/helm/kyverno-policies/values.yaml
+++ b/helm/kyverno-policies/values.yaml
@@ -83,6 +83,13 @@ supplementalSecurityPolicies:
     restrict-external-ips:
       enabled: true
       mode: Audit
+      # failurePolicy controls how the admission webhook behaves when Kyverno is
+      # unreachable. Because this policy matches Services (writes to which include
+      # unrelated controllers such as kube-vip's LoadBalancer bookkeeping), leaving
+      # it at the Kyverno default of "Fail" means a transient Kyverno outage blocks
+      # all Service writes cluster-wide. Set to "Ignore" to fail open. Unset keeps
+      # the Kyverno default ("Fail"). Only meaningful to change while mode is Audit.
+      # failurePolicy: Ignore
 
     # restrict-sa-automount-sa-token ensures that ServiceAccounts do not automatically mount ServiceAccount tokens.
     restrict-sa-automount-sa-token:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/37214

## What

Adds an optional `failurePolicy` field to the `restrict-external-ips` supplemental policy. It defaults to unset, so the rendered policy is unchanged (inherits Kyverno's default `failurePolicy: Fail`). Setting it to `Ignore` makes the policy's admission webhook fail open.

## Why

`restrict-external-ips` matches `Service` resources and, like all Kyverno policies here, its webhook defaults to `failurePolicy: Fail` — so if Kyverno's admission controller is briefly unreachable, the API server rejects **all Service writes** cluster-wide.

We hit this in production: during a short control-plane blip, a kube-vip leader re-election tried to re-adopt a LoadBalancer VIP. kube-vip patches the Service as part of that; the patch was rejected because the Kyverno webhook was momentarily unavailable, and kube-vip responded by releasing the VIP and never re-announcing it — leaving the gateway VIP unreachable from off-cluster for ~3 days.

The policy ships in `Audit` mode, so it never actually blocks a Service write when Kyverno *is* up — it only reports. That makes the fail-closed behavior pure downside on this path: no enforcement when healthy, but a hard outage when Kyverno blips. This change lets operators align the failure behavior with the policy's intent by setting `failurePolicy: Ignore` while it runs in `Audit`.

## Usage

```yaml
supplementalSecurityPolicies:
  policies:
    restrict-external-ips:
      failurePolicy: Ignore   # fail open; safe while mode is Audit
```

## Notes

- No default behavior change; opt-in only.
- Scoped to `restrict-external-ips` (the affected policy). The same pattern can be extended to the other supplemental policies if wanted, but kept minimal here.
- If `restrict-external-ips` is ever switched to `Enforce`, `failurePolicy: Ignore` should be reconsidered (or paired with excluding trusted controllers), since fail-open then weakens real enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)